### PR TITLE
Added support for failing github check status if tests fail

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -8,6 +8,8 @@ on:
         required: false
       gist_name:
         required: false
+      fail_check_on_failed_tests:
+        required: false
   #push:
   #release:
   #  types: published

--- a/action.ps1
+++ b/action.ps1
@@ -100,8 +100,8 @@ function Publish-ToCheckRun {
     $bdy = @{
         name       = $report_name
         head_sha   = $ref
-        status     = $conclusion
-        conclusion = 'neutral'
+        status     = 'completed'
+        conclusion = $conclusion
         output     = @{
             title   = $report_title
             summary = "This run completed at ``$([datetime]::Now)``"

--- a/action.ps1
+++ b/action.ps1
@@ -84,6 +84,13 @@ function Publish-ToCheckRun {
     Write-ActionInfo "Resolve Repo Full Name as $repoFullName"
 
     Write-ActionInfo "Adding Check Run"
+    $conclusion = 'neutral'
+    if ($testResult.ResultSummary_outcome -eq "Failed") {
+        Write-ActionWarning "Found failing tests"
+        $conclusion = 'failure'
+
+    }
+
     $url = "https://api.github.com/repos/$repoFullName/check-runs"
     $hdr = @{
         Accept = 'application/vnd.github.antiope-preview+json'
@@ -92,7 +99,7 @@ function Publish-ToCheckRun {
     $bdy = @{
         name       = $report_name
         head_sha   = $ref
-        status     = 'completed'
+        status     = $conclusion
         conclusion = 'neutral'
         output     = @{
             title   = $report_title

--- a/action.ps1
+++ b/action.ps1
@@ -16,19 +16,20 @@ Import-Module GitHubActions
 . $PSScriptRoot/action_helpers.ps1
 
 $inputs = @{
-    test_results_path      = Get-ActionInput test_results_path
-    project_path           = Get-ActionInput project_path
-    no_restore             = Get-ActionInput no_restore
-    msbuild_configuration  = Get-ActionInput msbuild_configuration
-    msbuild_verbosity      = Get-ActionInput msbuild_verbosity
-    report_name            = Get-ActionInput report_name
-    report_title           = Get-ActionInput report_title
-    github_token           = Get-ActionInput github_token -Required
-    skip_check_run         = Get-ActionInput skip_check_run
-    gist_name              = Get-ActionInput gist_name
-    gist_badge_label       = Get-ActionInput gist_badge_label
-    gist_badge_message     = Get-ActionInput gist_badge_message
-    gist_token             = Get-ActionInput gist_token -Required
+    test_results_path           = Get-ActionInput test_results_path
+    project_path                = Get-ActionInput project_path
+    no_restore                  = Get-ActionInput no_restore
+    msbuild_configuration       = Get-ActionInput msbuild_configuration
+    msbuild_verbosity           = Get-ActionInput msbuild_verbosity
+    report_name                 = Get-ActionInput report_name
+    report_title                = Get-ActionInput report_title
+    github_token                = Get-ActionInput github_token -Required
+    skip_check_run              = Get-ActionInput skip_check_run
+    gist_name                   = Get-ActionInput gist_name
+    gist_badge_label            = Get-ActionInput gist_badge_label
+    gist_badge_message          = Get-ActionInput gist_badge_message
+    gist_token                  = Get-ActionInput gist_token -Required
+    fail_check_on_failed_tests  = Get-ActionInput fail_check_on_failed_tests
 }
 
 $tmpDir = Join-Path $PWD _TMP
@@ -85,7 +86,7 @@ function Publish-ToCheckRun {
 
     Write-ActionInfo "Adding Check Run"
     $conclusion = 'neutral'
-    if ($testResult.ResultSummary_outcome -eq "Failed") {
+    if ($testResult.ResultSummary_outcome -eq "Failed" -and $inputs.fail_check_on_failed_tests) {
         Write-ActionWarning "Found failing tests"
         $conclusion = 'failure'
 

--- a/action.yml
+++ b/action.yml
@@ -111,6 +111,12 @@ inputs:
       You can control which account is used to actually store the state by
       generating a token associated with the target account.
 
+  fail_check_on_failed_tests:
+    description: |
+      If set to true, GitHub check status will be set to 'failure' 
+      if at least one test fails
+
+
 
 ## Here you describe your *formal* outputs.
 outputs:


### PR DESCRIPTION
Added support for marking the GitHub check status as `failure` if at least one test fails based on a new input flag `fail_check_on_failed_tests`