### PR TITLE
Create $tmp dir if it doesn't exist

### DIFF
--- a/action.ps1
+++ b/action.ps1
@@ -36,6 +36,8 @@ $tmpDir = Join-Path $PWD _TMP
 $test_results_path = $inputs.test_results_path
 $test_report_path = Join-Path $tmpDir test-results.md
 
+New-Item -Name $tmpDir -ItemType "directory" -Force
+
 function Build-MarkdownReport {
     $script:report_name = $inputs.report_name
     $script:report_title = $inputs.report_title


### PR DESCRIPTION
I was encountering an error with $tmp folder not existing when running the action using `test_results_path`

This makes sure the `$tmp` path exists. 