### PR TITLE
Add support for extra parameters and for failing build if tests fail

### DIFF
--- a/action.ps1
+++ b/action.ps1
@@ -284,14 +284,16 @@ else {
         $dotnetArgs += '--no-restore'
     }
 
-    if ($inputs.project_path) {
-        $dotnetArgs += $inputs.project_path
-    }
-    
     if ($inputs.extra_test_parameters) {
         $dotnetArgs += ' '
         $dotnetArgs += $inputs.extra_test_parameters
     }
+
+    # The project path has to be after all switches so this needs to be last
+    if ($inputs.project_path) {
+        $dotnetArgs += $inputs.project_path
+    }
+    
 
     Write-ActionInfo "Assembled test invocation arguments:"
     Write-ActionInfo "    $dotnetArgs"

--- a/action.ps1
+++ b/action.ps1
@@ -280,13 +280,14 @@ else {
         $dotnetArgs += '--configuration'
         $dotnetArgs += $msbuild_configuration
     }
+    
     if ($no_restore -eq 'true') {
         $dotnetArgs += '--no-restore'
     }
 
     if ($inputs.extra_test_parameters) {
-        $dotnetArgs += ' '
-        $dotnetArgs += $inputs.extra_test_parameters
+        # we need to add the extra parameters to the array @dotnetArgs
+        $dotnetArgs += $inputs.extra_test_parameters -split ' '
     }
 
     # The project path has to be after all switches so this needs to be last
@@ -294,7 +295,6 @@ else {
         $dotnetArgs += $inputs.project_path
     }
     
-
     Write-ActionInfo "Assembled test invocation arguments:"
     Write-ActionInfo "    $dotnetArgs"
 

--- a/action.ps1
+++ b/action.ps1
@@ -288,9 +288,9 @@ else {
         $dotnetArgs += $inputs.project_path
     }
     
-    if ($extra_test_parameters) {
+    if ($inputs.extra_test_parameters) {
         $dotnetArgs += ' '
-        $dotnetArgs += $extra_test_parameters
+        $dotnetArgs += $inputs.extra_test_parameters
     }
 
     Write-ActionInfo "Assembled test invocation arguments:"
@@ -300,7 +300,7 @@ else {
     & $dotnet.Path @dotnetArgs
 
     if (-not $?) {
-        if ($fail_build_on_failed_tests -eq 'true') {
+        if ($inputs.fail_build_on_failed_tests -eq 'true') {
             Write-ActionError "Tests failed so failing build..."
             exit 1
         } else {

--- a/action.yml
+++ b/action.yml
@@ -122,6 +122,14 @@ inputs:
       If specified, will override the default XSL transformation stylesheet
       used to convert TRX input file to a Markdown report.
 
+  extra_test_parameters:
+    description: |
+      Useful for passing extra parameters to dotnet test. Eg,
+      '--filter category=unit'
+      
+  fail_build_on_failed_tests:
+    description: |
+      If set to true, the build will fail if at least one test fails      
 
 
 ## Here you describe your *formal* outputs.


### PR DESCRIPTION
This PR adds support for being able to supply extra parameters to `Dotnet test` like `--filter category=fast` or `--no-build`, this addresses #10.  It also adds support for being able to fail the build if the tests fail, which is helpful because currently if any tests fail there's no way to tell from the pull request. 

Two new parameters have been introduced:

`fail_build_on_failed_tests` - boolean, set to `true` to fail the build if any tests fail. The report is still generated

`extra_test_parameters`  - string, useful for adding extra parameters to dotnet test. Eg, `--collect:"XPlat Code Coverage"`

These can be used like so:

```yaml
 - name: Test
    uses: zyborg/dotnet-tests-report@master
    with:
      project_path: myproject.csproj
      ...
      fail_build_on_failed_tests: true
      extra_test_parameters: '--no-build --filter "category=unit"'
```

These changes are backwards compatible, if the parameters aren't supplied things should (ha) continue to work as before. 

I am by means a powershell/github actions guru so please double check my changes! They seemed to work ok for me :)